### PR TITLE
add support for specifying a private key and header fields

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -67,6 +67,11 @@ module.exports.templateTags = [{
       encoding: 'base64',
     },
     {
+      displayName: 'Header (JSON format)',
+      type: 'string',
+      defaultValue: '{}',
+    },
+    {
       displayName: 'Secret',
       type: 'string',
       defaultValue: '',
@@ -77,9 +82,10 @@ module.exports.templateTags = [{
       defaultValue: '',
     },
   ],
-  async run(context, algorithm, iss, sub, aud, nbf, exp, jti, more, secret, privateKey) {
+  async run(context, algorithm, iss, sub, aud, nbf, exp, jti, payloadJson, headerJson, secret, privateKey) {
     const now = Math.round(Date.now() / 1000);
-    const payload = JSON.parse(more); // may throw error
+    const payload = JSON.parse(payloadJson); // may throw error
+    const header = JSON.parse(headerJson) // may throw error
 
     if (iss) {
       payload.iss = iss;
@@ -109,6 +115,6 @@ module.exports.templateTags = [{
       secret = fs.readFileSync(privateKey);
     }
 
-    return jwt.sign(payload, secret, { algorithm });
+    return jwt.sign(payload, secret, { algorithm, header });
   },
 }];

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const jwt = require('jsonwebtoken');
 const { v4: uuidv4 } = require('uuid');
 
@@ -70,8 +71,13 @@ module.exports.templateTags = [{
       type: 'string',
       defaultValue: '',
     },
+    {
+      displayName: 'Private Key File Path (has precedence over "Secret")',
+      type: 'string',
+      defaultValue: '',
+    },
   ],
-  async run(context, algorithm, iss, sub, aud, nbf, exp, jti, more, secret) {
+  async run(context, algorithm, iss, sub, aud, nbf, exp, jti, more, secret, privateKey) {
     const now = Math.round(Date.now() / 1000);
     const payload = JSON.parse(more); // may throw error
 
@@ -97,6 +103,10 @@ module.exports.templateTags = [{
 
     if (jti !== 'no') {
       payload.jti = uuidv4();
+    }
+
+    if (privateKey) {
+      secret = fs.readFileSync(privateKey);
     }
 
     return jwt.sign(payload, secret, { algorithm });


### PR DESCRIPTION
I guess the title says it all.

Both are necessary for when you want to generate JWTs for the [Apple App Store Connect API](https://developer.apple.com/documentation/appstoreconnectapi/generating_tokens_for_api_requests).

Passing in a file path for a private key will have precedence over the "Secret" option.