### PR TITLE
fix(readme): adjust grammar for empty fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Install the `insomnia-plugin-jwtcreator` plugin from Preferences > Plugins.
 ## Usage
 
 Add the `JSON Web Token Creator` template tag wherever you see fit and fill the
-necessary fields. Whichever you'll leve empty won't be present in the token.
+necessary fields. Any field left empty won't be present in the token.
 
 The recommended way to set up is to create environment variables to (at least)
 `iss`, `sub` and `secret`, and use those variables inside the


### PR DESCRIPTION
Fixes issue where leave was spelled leve by reformatting sentence voice and structure and using `left` instead.