### PR TITLE
Added the possibility to not generate iat

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -52,15 +52,6 @@ module.exports.templateTags = [{
       defaultValue: 10,
     },
     {
-      displayName: 'Generate IAT Timestamp (iat)',
-      type: 'enum',
-      defaultValue: 'no',
-      options: [
-        { displayName: 'No', value: 'no', description: "Don't set IAT timestamp" },
-        { displayName: 'Yes', value: 'yes', description: 'Set IAT timestamp' },
-      ],
-    },
-    {
       displayName: 'JWT ID (jti)',
       type: 'enum',
       defaultValue: 'UUIDv4',
@@ -90,6 +81,15 @@ module.exports.templateTags = [{
       type: 'string',
       defaultValue: '',
     },
+    {
+      displayName: 'Generate IAT Timestamp (iat)',
+      type: 'enum',
+      defaultValue: 'yes',
+      options: [
+        { displayName: 'No', value: 'no', description: "Don't set IAT timestamp" },
+        { displayName: 'Yes', value: 'yes', description: 'Set IAT timestamp' },
+      ],
+    },
   ],
   async run(
     context,
@@ -99,12 +99,12 @@ module.exports.templateTags = [{
     aud,
     nbf,
     exp,
-    iat,
     jti,
     more,
     secret,
     headerJson,
     privateKey,
+    iat,
   ) {
     const now = Math.round(Date.now() / 1000);
     const payload = JSON.parse(more); // may throw error

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -52,6 +52,15 @@ module.exports.templateTags = [{
       defaultValue: 10,
     },
     {
+      displayName: 'Generate IAT Timestamp (iat)',
+      type: 'enum',
+      defaultValue: 'no',
+      options: [
+        { displayName: 'No', value: 'no', description: "Don't set IAT timestamp" },
+        { displayName: 'Yes', value: 'yes', description: 'Set IAT timestamp' },
+      ],
+    },
+    {
       displayName: 'JWT ID (jti)',
       type: 'enum',
       defaultValue: 'UUIDv4',
@@ -90,6 +99,7 @@ module.exports.templateTags = [{
     aud,
     nbf,
     exp,
+    iat,
     jti,
     more,
     secret,
@@ -99,6 +109,7 @@ module.exports.templateTags = [{
     const now = Math.round(Date.now() / 1000);
     const payload = JSON.parse(more); // may throw error
     let header;
+    let noTimestamp = true;
 
     try {
       header = JSON.parse(headerJson);
@@ -126,6 +137,10 @@ module.exports.templateTags = [{
       payload.exp = now + exp;
     }
 
+    if (iat === 'yes') {
+      noTimestamp = false;
+    }
+
     if (jti !== 'no') {
       payload.jti = uuidv4();
     }
@@ -133,9 +148,9 @@ module.exports.templateTags = [{
     if (privateKey) {
       const privateKeyContent = fs.readFileSync(privateKey);
 
-      return jwt.sign(payload, privateKeyContent, { algorithm, header });
+      return jwt.sign(payload, privateKeyContent, { algorithm, header, noTimestamp });
     }
 
-    return jwt.sign(payload, secret, { algorithm, header });
+    return jwt.sign(payload, secret, { algorithm, header, noTimestamp });
   },
 }];

--- a/test/index.js
+++ b/test/index.js
@@ -6,8 +6,8 @@ const secret = 'leSecret';
 
 describe('Test plugin', () => {
   it('Generates bare token', (done) => {
-    // (context, algorithm, iss, sub, aud, nbf, exp, jti, more, secret)
-    plugin.run(null, 'HS256', '', '', '', '', '', '', '{}', secret)
+    // (context, algorithm, iss, sub, aud, nbf, exp, iat, jti, more, secret)
+    plugin.run(null, 'HS256', '', '', '', '', '', 'yes', '', '{}', secret)
       .then((token) => {
         const decodedToken = jwt.verify(token, secret);
         assert.property(decodedToken, 'iat');
@@ -17,8 +17,18 @@ describe('Test plugin', () => {
       });
   });
 
+  it('Generates bare token without iat', (done) => {
+    // (context, algorithm, iss, sub, aud, nbf, exp, iat, jti, more, secret)
+    plugin.run(null, 'HS256', '', '', '', '', '', 'no', '', '{}', secret)
+      .then((token) => {
+        const decodedToken = jwt.verify(token, secret);
+        assert.notProperty(decodedToken, 'iat');
+        done();
+      });
+  });
+
   it('Generates with custom payload', (done) => {
-    plugin.run(null, 'HS256', '', '', '', '', '', '', '{"test": "test"}', secret)
+    plugin.run(null, 'HS256', '', '', '', '', '', 'yes', '', '{"test": "test"}', secret)
       .then((token) => {
         const decodedToken = jwt.verify(token, secret, { algorithms: ["HS256"] });
         assert.property(decodedToken, 'iat');

--- a/test/index.js
+++ b/test/index.js
@@ -6,8 +6,8 @@ const secret = 'leSecret';
 
 describe('Test plugin', () => {
   it('Generates bare token', (done) => {
-    // (context, algorithm, iss, sub, aud, nbf, exp, iat, jti, more, secret)
-    plugin.run(null, 'HS256', '', '', '', '', '', 'yes', '', '{}', secret)
+    // (context, algorithm, iss, sub, aud, nbf, exp, jti, more, secret, headerJson, iat, privateKey)
+    plugin.run(null, 'HS256', '', '', '', '', '', '', '{}', secret, '{}', '', 'yes')
       .then((token) => {
         const decodedToken = jwt.verify(token, secret);
         assert.property(decodedToken, 'iat');
@@ -18,8 +18,8 @@ describe('Test plugin', () => {
   });
 
   it('Generates bare token without iat', (done) => {
-    // (context, algorithm, iss, sub, aud, nbf, exp, iat, jti, more, secret)
-    plugin.run(null, 'HS256', '', '', '', '', '', 'no', '', '{}', secret)
+    // (context, algorithm, iss, sub, aud, nbf, exp, jti, more, secret, headerJson, iat, privateKey)
+    plugin.run(null, 'HS256', '', '', '', '', '',  '', '{}', secret, '{}', '', 'no')
       .then((token) => {
         const decodedToken = jwt.verify(token, secret);
         assert.notProperty(decodedToken, 'iat');
@@ -28,7 +28,7 @@ describe('Test plugin', () => {
   });
 
   it('Generates with custom payload', (done) => {
-    plugin.run(null, 'HS256', '', '', '', '', '', 'yes', '', '{"test": "test"}', secret)
+    plugin.run(null, 'HS256', '', '', '', '', '', '', '{"test": "test"}', secret, '{}', '', 'yes')
       .then((token) => {
         const decodedToken = jwt.verify(token, secret, { algorithms: ["HS256"] });
         assert.property(decodedToken, 'iat');


### PR DESCRIPTION
Hello,
I had the problem that the iat was causing a problem with clock skew and jwt checks.
I added the possibility to not create the iat. 
It is basically passing the option noTimestamp (true / false) to jwt.sign().

Cheers
Benedikt